### PR TITLE
Allow customisation of no_proxy_on option

### DIFF
--- a/chrome/content/options.xul
+++ b/chrome/content/options.xul
@@ -4,7 +4,6 @@
 
 <vbox xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
   <setting pref="network.proxy.type" type="boolint" on="1" off="2" title="Use Proxy"/>
-  <setting pref="network.proxy.no_proxies_on" type="string" title="no proxy on"/>
   <setting pref="network.proxy.http" type="string" title="HTTP Proxy Host"/>
   <setting pref="extensions.proxymob.network.proxy.http_port" type="string" title="HTTP Proxy Port"/> 
   <setting pref="network.proxy.socks" type="string" title="SOCKS Proxy Host"/>
@@ -12,6 +11,7 @@
   <setting pref="network.proxy.socks_remote_dns" type="bool" title="SOCKS Remote DNS"/>
   <setting pref="network.proxy.ssl" type="string" title="SSL Proxy Host"/>
   <setting pref="extensions.proxymob.network.proxy.ssl_port" type="string" title="SSL Proxy Port"/>
+  <setting pref="network.proxy.no_proxies_on" type="string" title="Bypass Proxy For"/>
 </vbox>
 
 

--- a/chrome/content/options.xul
+++ b/chrome/content/options.xul
@@ -4,6 +4,7 @@
 
 <vbox xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
   <setting pref="network.proxy.type" type="boolint" on="1" off="2" title="Use Proxy"/>
+  <setting pref="network.proxy.no_proxies_on" type="string" title="no proxy on"/>
   <setting pref="network.proxy.http" type="string" title="HTTP Proxy Host"/>
   <setting pref="extensions.proxymob.network.proxy.http_port" type="string" title="HTTP Proxy Port"/> 
   <setting pref="network.proxy.socks" type="string" title="SOCKS Proxy Host"/>

--- a/defaults/preferences/prefs.js
+++ b/defaults/preferences/prefs.js
@@ -9,4 +9,4 @@ pref("network.proxy.socks_port", 9050);
 pref("extensions.proxymob.network.proxy.socks_port", "9050");
 pref("network.proxy.type", 1);
 pref("network.proxy.socks_remote_dns",true);
-
+pref("network.websocket.enabled",false);

--- a/install.rdf
+++ b/install.rdf
@@ -1,23 +1,22 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<RDF:RDF xmlns:em="http://www.mozilla.org/2004/em-rdf#"
-         xmlns:NC="http://home.netscape.com/NC-rdf#"
-         xmlns:RDF="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-  <RDF:Description RDF:about="urn:mozilla:install-manifest"
-                   em:id="proxymob@guardianproject.info"
-                   em:name="Proxy Mobile"
-                   em:version="0.0.8"
-                   em:creator="https://guardianproject.info"
-                   em:description="Proxy Settings :: https://guardianproject.info">
-<em:optionsURL>chrome://proxymob/content/options.xul</em:optionsURL>
-<em:targetApplication>
-  <!-- Fennec -->
-  <Description>
-    <em:id>{a23983c0-fd0e-11dc-95ff-0800200c9a66}</em:id>
-    <em:minVersion>1.1</em:minVersion>
-    <em:maxVersion>14.0.1</em:maxVersion>
-  </Description>
-</em:targetApplication>
-  </RDF:Description>
-</RDF:RDF>
-
-
+<?xml version="1.0"?>
+<RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+    <Description about="urn:mozilla:install-manifest">
+        <em:id>proxymob@guardianproject.info</em:id>
+        <em:type>2</em:type>
+        <em:name>Proxy Mobile</em:name>
+        <em:version>0.0.10</em:version>
+        <em:bootstrap>false</em:bootstrap>
+        <em:description>Simple Proxy Settings for HTTP and SOCKS</em:description>
+        <em:creator>The Guardian Project</em:creator>
+	<em:optionsURL>chrome://proxymob/content/options.xul</em:optionsURL>
+ 
+        <!-- Mobile Native -->
+        <em:targetApplication>
+            <Description>
+                <em:id>{aa3c5121-dab2-40e2-81ca-7ea25febc110}</em:id>
+                <em:minVersion>10.0</em:minVersion>
+                <em:maxVersion>15.*</em:maxVersion>
+            </Description>
+        </em:targetApplication>
+    </Description>
+</RDF>

--- a/install.rdf
+++ b/install.rdf
@@ -14,7 +14,7 @@
   <Description>
     <em:id>{a23983c0-fd0e-11dc-95ff-0800200c9a66}</em:id>
     <em:minVersion>1.1</em:minVersion>
-    <em:maxVersion>6.0a1</em:maxVersion>
+    <em:maxVersion>14.0.1</em:maxVersion>
   </Description>
 </em:targetApplication>
   </RDF:Description>


### PR DESCRIPTION
Sometimes it is convenient to access local services that only listen on the loopback device through a proxy. This change allows you to change which domains bypass the proxy.
